### PR TITLE
Specialize the Symbol Index files to source.c

### DIFF
--- a/Symbol Index (function declaration).tmPreferences
+++ b/Symbol Index (function declaration).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.function.declaration</string>
+    <string>source.c entity.name.function.declaration</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (function).tmPreferences
+++ b/Symbol Index (function).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.function</string>
+    <string>source.c entity.name.function</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (macro function).tmPreferences
+++ b/Symbol Index (macro function).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.function.macro</string>
+    <string>source.c entity.name.function.macro</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (macro object).tmPreferences
+++ b/Symbol Index (macro object).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.variable.macro</string>
+    <string>source.c entity.name.variable.macro</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (type declaration).tmPreferences
+++ b/Symbol Index (type declaration).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.type.declaration</string>
+    <string>source.c entity.name.type.declaration</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (type).tmPreferences
+++ b/Symbol Index (type).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.type</string>
+    <string>source.c entity.name.type</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index (typedef).tmPreferences
+++ b/Symbol Index (typedef).tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.type.typedef</string>
+    <string>source.c entity.name.type.typedef</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>


### PR DESCRIPTION
Now they don't trample on the Symbol Index definitions from the C++ package, or any other language for that matter (I noticed it in Python as well).
