### PR TITLE
added highlighting on wrong line continuitation

### DIFF
--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -82,12 +82,12 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key> <string>(?&gt;\\\n)</string>
+					<key>match</key> <string>(?&gt;\\(\s*)\n)</string>
 					<key>name</key> <string>punctuation.separator.continuation.c</string>
-				</dict>
-				<dict>
-					<key>match</key> <string>(?&gt;\\\s+\n)</string>
-					<key>name</key> <string>invalid.illegal.space-after-continuation.c</string>
+					<key>captures</key>
+				        <dict>
+				            <key>1</key> <dict> <key>name</key> <string>invalid.illegal.space-after-continuation.c</string> </dict>
+				        </dict>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Hey abusalimov, 

I'd propose a small addition for C improved. It highlights spaces between '\' and '\n'. Yesterday I had a long run finding an errror because of this, so I thought it could be useful.

greetings from germany
Andi
