### PR TITLE
function-call: Highlight as 'support.function.any-method.c' by default

### DIFF
--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -371,7 +371,11 @@
 			<key>patterns</key>
 			<array>
 				<dict> <key>include</key> <string>#lex</string> </dict>
-				<dict> <key>include</key> <string>#support</string> </dict>
+				<dict> <key>include</key> <string>#support-function</string> </dict>
+				<dict>
+					<key>match</key> <string>(?:[A-Za-z_]\w*+|::[^:])++</string>
+					<key>name</key> <string>support.function.any-method.c</string>
+				</dict>
 				<dict> <key>include</key> <string>#parens-lookahead-end</string> </dict>
 			</array>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -106,11 +106,6 @@ C can be quite complicated to parse in some parts, for example related to pointe
 
 Some discussion on this can be found in a related [issue](//github.com/abusalimov/SublimeCImproved/issues/8).
 
-### Highlighting of all function calls
-In C Improved only calls to special support functions (like `printf`) are highlighted, unlike the standard C which highlights all function calls. This is the intended behavior that aims to make the highlighting more informative by emphasizing library functions and consistent with syntax definitions of other languages.
-
-A related [issue](//github.com/abusalimov/SublimeCImproved/issues/11) contains some hints on how to restore the original behavior.
-
 Installation
 ---
 ### Package Control


### PR DESCRIPTION
Also only consider support functions in calls, i.e. exclude support types.

This restores initial behavior of the standard package:

    printf();    // support.function.C99.c
    my_func();   // support.function.any-method.c

References #15 ("Losing highlighting in numbers, struct members & function calls")
Closes #11 ("Causes function calls to lose their highlighting")