### PR TITLE
preproc: Make end patterns more sensitive

### DIFF
--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -415,7 +415,7 @@
 				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
 				<dict>
 					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
 				</dict>
 				<dict>
@@ -424,7 +424,7 @@
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.define.c</string> </dict>
 					</dict>
-					<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 					<key>name</key> <string>meta.preprocessor.directive.c</string>
 					<key>patterns</key>
 					<array>
@@ -447,7 +447,7 @@
 				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
 				<dict>
 					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
 				</dict>
 			</array>
@@ -459,10 +459,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?x)
-				(?: (?&lt;=^|[^\\])\s*(?=\n)$\n?
-				  | (?&lt;= [^\\]\n ) | (?&lt;= \A\n ) )  # unexpected end of line
-			</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.macro.c</string>
 			<key>patterns</key>
 			<array>
@@ -635,7 +632,7 @@
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 				<key>4</key> <dict> <key>name</key> <string>variable.macro.undef.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.undef.c</string>
 			<key>patterns</key>
 			<array>
@@ -649,7 +646,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.include.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?:("[^"]*?)|(&lt;[^&gt;]*?))(\n)|(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?:("[^"]*?)|(&lt;[^&gt;]*?))(\n)|(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>string.quoted.double.include.c</string> </dict>
@@ -711,7 +708,7 @@
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.pragma.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.pragma-mark.c</string>
 			<key>contentName</key> <string>meta.toc-list.pragma-mark.c</string>
 			<key>patterns</key>
@@ -730,7 +727,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.c</string>
 			<key>patterns</key>
 			<array>
@@ -752,7 +749,7 @@
 		<key>ppline-directive-obsolete</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)\s*(assert|unassert|ident|sccs)\b</string>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.c invalid.deprecated.preprocessor.c</string>
 			<key>patterns</key>
 			<array>
@@ -763,7 +760,7 @@
 		<key>ppline-invalid</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)(?!\s*(?=/[/*]|(?&gt;\\\s*\n)|\n|$))</string>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.c invalid.illegal.preprocessor.c</string>
 		</dict>
 
@@ -774,7 +771,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.null-directive.c</string>
 			<key>patterns</key>
 			<array>
@@ -1025,7 +1022,7 @@
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
 					</dict>
-					<key>end</key> <string>(?&lt;=^|[^\\])\s*(?=\n)$\n?</string>
+					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
 					<key>name</key> <string>comment.line.double-slash.c++</string>
 					<key>patterns</key>
 					<array>


### PR DESCRIPTION
Apply the regex used for macros for the rest preprocessor rules.

This is necessary to make preprocessor rules exit even if a newline, which used to trigger end patterns (`(?=\n)$\n?`), is consumed by some inner rule, like a // single-line comment.

Fixes #18 ("Include directive miscolored when preceded by single-line comment")