### PR TITLE
Newline handling in preprocessor and comments

### DIFF
--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -409,6 +409,7 @@
 			<array>
 				<dict> <key>include</key> <string>#comments</string> </dict>
 				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
+				<dict> <key>include</key> <string>#lex-newline</string> </dict>
 			</array>
 		</dict>
 		<key>preprocessor-disabled</key>
@@ -1011,17 +1012,22 @@
 					<key>captures</key>
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.block.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
 					</dict>
-					<key>match</key> <string>^\s*/\* =(\s*.*?)\s*= \*/$\n?</string>
+					<key>match</key> <string>^\s*/\* =(\s*.*?)\s*= \*/$(\n?)</string>
 					<key>name</key> <string>comment.block.c</string>
 				</dict>
 				<dict>
-					<key>begin</key> <string>\s*/\*</string>
+					<key>begin</key> <string>\s*(/\*)</string>
 					<key>captures</key>
 					<dict>
-						<key>0</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
 					</dict>
-					<key>end</key> <string>\*/</string>
+					<key>end</key> <string>(\*/)(\n?)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
+					</dict>
 					<key>name</key> <string>comment.block.c</string>
 				</dict>
 				<dict>
@@ -1032,8 +1038,9 @@
 					<key>captures</key>
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.line.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
 					</dict>
-					<key>match</key> <string>^\s*// =(\s*.*?)\s*=\s*$\n?</string>
+					<key>match</key> <string>^\s*// =(\s*.*?)\s*=\s*$(\n?)</string>
 					<key>name</key> <string>comment.line.banner.c++</string>
 				</dict>
 				<dict>
@@ -1047,6 +1054,7 @@
 					<key>patterns</key>
 					<array>
 						<dict> <key>include</key> <string>#lex-continuation</string> </dict>
+						<dict> <key>include</key> <string>#lex-newline</string> </dict>
 					</array>
 				</dict>
 			</array>
@@ -1076,6 +1084,7 @@
 				<dict> <key>include</key> <string>#comments</string> </dict>
 				<dict> <key>include</key> <string>#lex-access</string> </dict>
 				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
+				<dict> <key>include</key> <string>#lex-newline</string> </dict>
 				<dict> <key>include</key> <string>#lex-number</string> </dict>
 				<dict> <key>include</key> <string>#lex-string</string> </dict>
 			</array>
@@ -1092,11 +1101,12 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key> <string>(\\)$\n?</string>
+					<key>match</key> <string>(\\)$(\n?)</string>
 					<key>name</key> <string>punctuation.separator.continuation.c</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>keyword.other.line-continuation.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
 					</dict>
 				</dict>
 				<dict>
@@ -1108,6 +1118,12 @@
 				</dict>
 			</array>
 		</dict>
+		<key>lex-newline</key>
+		<dict>
+			<key>match</key> <string>$\n</string>
+			<key>name</key> <string>punctuation.whitespace.newline.c</string>
+		</dict>
+
 		<key>lex-keyword</key>
 		<dict>
 			<key>patterns</key>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -413,22 +413,26 @@
 		</dict>
 		<key>preprocessor-disabled</key>
 		<dict>
-			<key>begin</key> <string>^\s*(#)(?=\s*(if)\s+(0[xX])?0++\b)</string>
+			<key>begin</key> <string>^\s*(#)(?=\s*(if)\b(?=(?:\s|/\*.*?\*/)*+(0[xX])?0++\b(?:\s|/\*.*?\*/)*+(//.*)?\\?$))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>meta.preprocessor.directive.c keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?=^\s*(#)\s*(endif|else|elif))</string>
+			<key>end</key> <string>(?=^\s*(#)\s*(endif|else|elif)\b)</string>
 			<key>patterns</key>
 			<array>
-				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
 				<dict>
-					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
+					<key>begin</key> <string>^</string>
+					<key>end</key> <string>$\n?</string>
 					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
+						<dict> <key>include</key> <string>#preprocessor-disabled-directive</string> </dict>
+					</array>
 				</dict>
 				<dict>
-					<key>begin</key> <string>(?&lt;!##)(?&lt;=#)(\s*if)\s+(?=(0[xX])?0++\b)</string>
+					<key>begin</key> <string>(?&lt;!##)(?&lt;=#)\s*(if)\b(?=(?:\s|/\*.*?\*/)*+(0[xX])?0++\b(?:\s|/\*.*?\*/)*+(//.*)?\\?$)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.define.c</string> </dict>
@@ -440,27 +444,24 @@
 						<dict> <key>include</key> <string>#lex-core</string> </dict>
 					</array>
 				</dict>
-				<dict>
-					<key>match</key> <string>.</string>
-					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
-				</dict>
 			</array>
 		</dict>
 		<key>preprocessor-disabled-conditional</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)\s*if(n?def)?\b</string>
-			<key>end</key> <string>^\s*(#)\s*endif\b.*$</string>
-			<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
+			<key>end</key> <string>^\s*(#)\s*endif\b.*$\n?</string>
 			<key>patterns</key>
 			<array>
 				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
-				<dict>
-					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
-					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
-				</dict>
+				<dict> <key>include</key> <string>#preprocessor-disabled-directive</string> </dict>
 			</array>
 		</dict>
+		<key>preprocessor-disabled-directive</key>
+		<dict>
+			<key>begin</key> <string>^\s*(#)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
+		</dict>
+
 		<key>ppline-macro</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)(?=\s*(define)\s+[a-zA-Z_]\w*+)</string>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -759,7 +759,12 @@
 		<dict>
 			<key>begin</key> <string>^\s*(#)\s*(assert|unassert|ident|sccs)\b</string>
 			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
-			<key>name</key> <string>meta.preprocessor.directive.c invalid.deprecated.preprocessor.c</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
+				<key>2</key> <dict> <key>name</key> <string>invalid.deprecated.preprocessor.c</string> </dict>
+			</dict>
+			<key>name</key> <string>meta.preprocessor.directive.deprecated.c</string>
 			<key>patterns</key>
 			<array>
 				<dict> <key>include</key> <string>#lex-core</string> </dict>
@@ -768,9 +773,14 @@
 
 		<key>ppline-invalid</key>
 		<dict>
-			<key>begin</key> <string>^\s*(#)(?!\s*(?=/[/*]|(?&gt;\\\s*\n)|\n|$))</string>
+			<key>begin</key> <string>^\s*(#)(?!\s*(?=/[/*]|(?&gt;\\\s*\n)|\n|$))\s*(\w*)</string>
 			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
-			<key>name</key> <string>meta.preprocessor.directive.c invalid.illegal.preprocessor.c</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
+				<key>2</key> <dict> <key>name</key> <string>invalid.illegal.preprocessor.c</string> </dict>
+			</dict>
+			<key>name</key> <string>meta.preprocessor.directive.illegal.c</string>
 		</dict>
 
 		<key>ppline-any</key>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -424,7 +424,7 @@
 				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
 				<dict>
 					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
 				</dict>
 				<dict>
@@ -433,7 +433,7 @@
 					<dict>
 						<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.define.c</string> </dict>
 					</dict>
-					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 					<key>name</key> <string>meta.preprocessor.directive.c</string>
 					<key>patterns</key>
 					<array>
@@ -456,7 +456,7 @@
 				<dict> <key>include</key> <string>#preprocessor-disabled-conditional</string> </dict>
 				<dict>
 					<key>begin</key> <string>^\s*(#)</string>
-					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 					<key>name</key> <string>comment.other.preprocessor-disabled.c</string>
 				</dict>
 			</array>
@@ -468,7 +468,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>name</key> <string>meta.preprocessor.macro.c</string>
 			<key>patterns</key>
 			<array>
@@ -641,7 +641,7 @@
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 				<key>4</key> <dict> <key>name</key> <string>variable.macro.undef.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>name</key> <string>meta.preprocessor.undef.c</string>
 			<key>patterns</key>
 			<array>
@@ -655,7 +655,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.include.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?:("[^"]*?)|(&lt;[^&gt;]*?))(\n)|(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?:("[^"]*?)|(&lt;[^&gt;]*?))(\n)|(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>string.quoted.double.include.c</string> </dict>
@@ -717,7 +717,7 @@
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.pragma.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.pragma-mark.c</string>
 			<key>contentName</key> <string>meta.toc-list.pragma-mark.c</string>
 			<key>patterns</key>
@@ -736,7 +736,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.c</string>
 			<key>patterns</key>
 			<array>
@@ -758,7 +758,7 @@
 		<key>ppline-directive-obsolete</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)\s*(assert|unassert|ident|sccs)\b</string>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
@@ -774,7 +774,7 @@
 		<key>ppline-invalid</key>
 		<dict>
 			<key>begin</key> <string>^\s*(#)(?!\s*(?=/[/*]|(?&gt;\\\s*\n)|\n|$))\s*(\w*)</string>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
@@ -790,7 +790,7 @@
 			<dict>
 				<key>0</key> <dict> <key>name</key> <string>keyword.other.preprocessor.c</string> </dict>
 			</dict>
-			<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+			<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 			<key>name</key> <string>meta.preprocessor.directive.null-directive.c</string>
 			<key>patterns</key>
 			<array>
@@ -1041,7 +1041,7 @@
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
 					</dict>
-					<key>end</key> <string>(?&lt;=^|[^\\])(?=\s*(//.*)?\n)$\n?|(?&lt;=[^\\]\n)|(?&lt;=\A\n)</string>
+					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 					<key>name</key> <string>comment.line.double-slash.c++</string>
 					<key>patterns</key>
 					<array>

--- a/tests/test_lexlines.c
+++ b/tests/test_lexlines.c
@@ -33,7 +33,35 @@ REGULAR LINE
 		str_expr, expr, ##args)
 
 #if 0
+comment
+#endif
+
+#if 0 // comment
+comment
+#endif
+
+#if /*1*/0
+comment
+#endif
+
+#if 0+1
+REGULAR LINE
+#endif
+
+#if 0
+comment
+#if 0
+#if 0
 #define COMMENT
+#endif
+#define COMMENT
+comment
+#endif
+#endif
+
+#if 0
+comment
+#endif_comment
 comment
 #endif
 

--- a/tests/test_lexlines.c
+++ b/tests/test_lexlines.c
@@ -1,0 +1,49 @@
+/* Tests for preprocessor rules, comments, line continuations, etc.*/
+
+#include <sys/neutrino.h>   // comment
+#include <sys/mman.h>       // comment
+
+#include <xxx.h> // comment \
+	comment
+REGULAR LINE
+
+#include <xxx.h> // comment \
+
+REGULAR LINE
+
+#include \
+<xxx.h>
+<REGULAR LINE>
+
+#define macro // comment \
+	comment
+#define macro() /* block comment \
+	comment */ body \
+#define NOT_A_NAME, still the body \
+	void not_a_function(void) {}
+
+#define exprintf(expr,         \
+		/* optional */ msg...) \
+	__exprintf(#expr,  \
+		(int) (expr),  \
+		"%s: %d\n" msg)
+#define __exprintf(str_expr, \
+		expr, fmt, args...)  \
+	printf(fmt, \
+		str_expr, expr, ##args)
+
+#if 0
+#define COMMENT
+comment
+#endif
+
+// comment \
+// comment \
+still a comment
+REGULAR LINE
+
+// comment /* block */ comment
+
+#assert <- DEPRECATED
+#sdfasd <- INVALID
+#line


### PR DESCRIPTION
Refactor and simplify end patterns of line-based rules (# preprocessor directives, // line comments, \ line continuations). See also: #20, #18, #4.
Also fix few minor issues with matching preprocessor directives.