### PR TITLE
Add support for task tags (TODO, FIXME, etc.)

### DIFF
--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -1078,6 +1078,9 @@
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-high.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>storage.type.class.fixme.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>storage.type.class.xxx.c</string> </dict>
+						<key>3</key> <dict> <key>name</key> <string>storage.type.class.wtf.c</string> </dict>
 					</dict>
 					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
 					<key>name</key> <string>meta.toc-list.task-tag.prio-high.c</string>
@@ -1095,6 +1098,7 @@
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-normal.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>storage.type.class.todo.c</string> </dict>
 					</dict>
 					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
 					<key>name</key> <string>meta.toc-list.task-tag.prio-normal.c</string>
@@ -1112,6 +1116,8 @@
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-low.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>storage.type.class.tbd.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>storage.type.class.review.c</string> </dict>
 					</dict>
 					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
 					<key>name</key> <string>meta.toc-list.task-tag.prio-low.c</string>
@@ -1129,6 +1135,13 @@
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.note.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>storage.type.class.note.c</string> </dict>
+						<key>2</key> <dict> <key>name</key> <string>storage.type.class.nb.c</string> </dict>
+						<key>3</key> <dict> <key>name</key> <string>storage.type.class.changed.c</string> </dict>
+						<key>4</key> <dict> <key>name</key> <string>storage.type.class.idea.c</string> </dict>
+						<key>5</key> <dict> <key>name</key> <string>storage.type.class.important.c</string> </dict>
+						<key>6</key> <dict> <key>name</key> <string>storage.type.class.hack.c</string> </dict>
+						<key>7</key> <dict> <key>name</key> <string>storage.type.class.bug.c</string> </dict>
 					</dict>
 					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
 					<key>name</key> <string>meta.toc-list.task-tag.note.c</string>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -1008,19 +1008,10 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.block.c</string> </dict>
-						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
-					</dict>
-					<key>match</key> <string>^\s*/\* =(\s*.*?)\s*= \*/$(\n?)</string>
-					<key>name</key> <string>comment.block.c</string>
-				</dict>
-				<dict>
 					<key>begin</key> <string>\s*(/\*)</string>
 					<key>captures</key>
 					<dict>
-						<key>1</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>punctuation.definition.comment.block.c</string> </dict>
 					</dict>
 					<key>end</key> <string>(\*/)(\n?)</string>
 					<key>endCaptures</key>
@@ -1028,35 +1019,49 @@
 						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
 					</dict>
 					<key>name</key> <string>comment.block.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#comment-innards</string> </dict>
+					</array>
 				</dict>
 				<dict>
 					<key>match</key> <string>\*/(?![/*])</string>
 					<key>name</key> <string>invalid.illegal.stray-comment-end.c</string>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.line.c</string> </dict>
-						<key>2</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
-					</dict>
-					<key>match</key> <string>^\s*// =(\s*.*?)\s*=\s*$(\n?)</string>
-					<key>name</key> <string>comment.line.banner.c++</string>
-				</dict>
-				<dict>
-					<key>begin</key> <string>\s*//</string>
+					<key>begin</key> <string>\s*(//)</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>0</key> <dict> <key>name</key> <string>punctuation.definition.comment.c</string> </dict>
+						<key>1</key> <dict> <key>name</key> <string>punctuation.definition.comment.line.double-slash.c++</string> </dict>
 					</dict>
 					<key>end</key> <string>(?&lt;=$\n)(?&lt;!\\$\n)</string>
 					<key>name</key> <string>comment.line.double-slash.c++</string>
 					<key>patterns</key>
 					<array>
-						<dict> <key>include</key> <string>#lex-continuation</string> </dict>
-						<dict> <key>include</key> <string>#lex-newline</string> </dict>
+						<dict> <key>include</key> <string>#comment-innards</string> </dict>
 					</array>
 				</dict>
 			</array>
+		</dict>
+
+		<key>comment-innards</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict> <key>include</key> <string>#comment-banner-line</string> </dict>
+				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
+				<dict> <key>include</key> <string>#lex-newline</string> </dict>
+			</array>
+		</dict>
+
+		<key>comment-banner-line</key>
+		<dict>
+			<key>match</key> <string>(?:(?&lt;=//)|(?&lt;=/\*)|^)[\s/*]*(=+\s*(.*?)\s*=+(?:(?=[\s/*+\-]*\*/)|$(\n?)))</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.c</string> </dict>
+				<key>3</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
+			</dict>
 		</dict>
 
 		<key>lex</key>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -1049,6 +1049,7 @@
 			<key>patterns</key>
 			<array>
 				<dict> <key>include</key> <string>#comment-banner-line</string> </dict>
+				<dict> <key>include</key> <string>#comment-task-tag-line</string> </dict>
 				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
 				<dict> <key>include</key> <string>#lex-newline</string> </dict>
 			</array>
@@ -1062,6 +1063,91 @@
 				<key>1</key> <dict> <key>name</key> <string>meta.toc-list.banner.c</string> </dict>
 				<key>3</key> <dict> <key>name</key> <string>punctuation.whitespace.newline.c</string> </dict>
 			</dict>
+		</dict>
+
+		<key>comment-task-tag-line</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key> <string>(?ix)
+					    (?= (?-i: @[a-zA-Z_]++ | \b [A-Z_]++) \b) @? \b (?:
+					        (FIXME) | (XXX) | (WTF)
+					    ) \b
+					</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-high.c</string> </dict>
+					</dict>
+					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
+					<key>name</key> <string>meta.toc-list.task-tag.prio-high.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#comment-task-tag-line-innards</string> </dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key> <string>(?ix)
+					    (?= (?-i: @[a-zA-Z_]++ | \b [A-Z_]++) \b) @? \b (?:
+					        (TODO)
+					    ) \b
+					</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-normal.c</string> </dict>
+					</dict>
+					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
+					<key>name</key> <string>meta.toc-list.task-tag.prio-normal.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#comment-task-tag-line-innards</string> </dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key> <string>(?ix)
+					    (?= (?-i: @[a-zA-Z_]++ | \b [A-Z_]++) \b) @? \b (?:
+					        (TBD) | (REVIEW)
+					    ) \b
+					</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.prio-low.c</string> </dict>
+					</dict>
+					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
+					<key>name</key> <string>meta.toc-list.task-tag.prio-low.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#comment-task-tag-line-innards</string> </dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key> <string>(?ix)
+					    (?= (?-i: @[a-zA-Z_]++ | \b [A-Z_]++) \b) @? \b (?:
+					        (NOTE) | (NB) | (CHANGED) | (IDEA) | (IMPORTANT) | (HACK) | (BUG)
+					    ) \b
+					</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key> <dict> <key>name</key> <string>keyword.other.task-tag.note.c</string> </dict>
+					</dict>
+					<key>end</key> <string>(?=[\s/*]*\*/)|(?&lt;=$\n)</string>
+					<key>name</key> <string>meta.toc-list.task-tag.note.c</string>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#comment-task-tag-line-innards</string> </dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+
+		<key>comment-task-tag-line-innards</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict> <key>include</key> <string>#comment-task-tag-line</string> </dict>
+				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
+				<dict> <key>include</key> <string>#lex-newline</string> </dict>
+			</array>
 		</dict>
 
 		<key>lex</key>

--- a/C Improved.tmLanguage
+++ b/C Improved.tmLanguage
@@ -1030,7 +1030,7 @@
 					<key>name</key> <string>comment.block.c</string>
 				</dict>
 				<dict>
-					<key>match</key> <string>\*/(?=[^*].*\n)</string>
+					<key>match</key> <string>\*/(?![/*])</string>
 					<key>name</key> <string>invalid.illegal.stray-comment-end.c</string>
 				</dict>
 				<dict>

--- a/tests/test_lexlines.c
+++ b/tests/test_lexlines.c
@@ -75,3 +75,29 @@ REGULAR LINE
 #assert <- DEPRECATED
 #sdfasd <- INVALID
 #line
+
+// === Task tags examples ===
+
+/*
+ * My awesome structure.
+ * More docs TBD -- Eldar */
+struct aww {}; // NOTE really awesome, but still empty
+               // new comment line      \
+               // and TODO continuation \
+               // still the same comment line
+               // simple multiline comment   \
+                  Hey you! FIXME -- PF       \
+                  Just another brick in the wall
+
+// XXX move to a header
+extern int barf(void);
+
+#pragma mark MAIN
+
+int main(int argc, char const *argv[])
+{
+	mode_t mode;
+	mode = S_IFBLK; // XXX this should be an argument
+	mode |= S_IRALL | S_IWALL; // TODO umask. -- Eldar
+	return 0;
+}


### PR DESCRIPTION
This basically introduces two new scopes: `meta.toc-list.task-tag` and `entity.other.task-tag`, plus their sub-scopes: `note`, `todo` and `fixme`.

Without the special support from color schemes, this only adds lines containing task tags to the `Ctrl+R` symbol index.

Also improves handling of `// === banner ===` comments.

Fixes #27 (almost).

Contains #28, do not merge!