### PR TITLE
Symbol index preferences

### DIFF
--- a/Symbol Index (function declaration).tmPreferences
+++ b/Symbol Index (function declaration).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - function declaration/g;
+		s/^.*$/ ⒡  $0 \( \) ; — function declaration/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (function).tmPreferences
+++ b/Symbol Index (function).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - function/g;
+		s/^.*$/—Ⓕ– $0 \( \) { … } — function/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (macro function).tmPreferences
+++ b/Symbol Index (macro function).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - macro function/g;
+		s/^.*$/—Ⓜ– $0 \( \) … — macro function/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (macro object).tmPreferences
+++ b/Symbol Index (macro object).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - macro object/g;
+		s/^.*$/ Ⓜ  $0 … — macro object/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (type declaration).tmPreferences
+++ b/Symbol Index (type declaration).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - type declaration/g;
+		s/^.*$/ ⒞  $0 ; — type declaration/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (type).tmPreferences
+++ b/Symbol Index (type).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - type/g;
+		s/^.*$/—Ⓒ– $0 { … } ; — type/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index (typedef).tmPreferences
+++ b/Symbol Index (typedef).tmPreferences
@@ -12,7 +12,7 @@
 		<string>1</string>
 		<key>symbolTransformation</key>
 		<string>
-		s/^.*$/$0 - typedef/g;
+		s/^.*$/ Ⓣ  $0 ; — typedef/g;
 		</string>
     </dict>
 </dict>

--- a/Symbol Index - TOC - Banner.tmPreferences
+++ b/Symbol Index - TOC - Banner.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.banner - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^=+\s*(.*?)\s*=+\s*\\?\s*$\n?/$1/mg;
+		s/^.*$/=== $0 ========================================================/g;
+		s/=  =/= ===/g;
+		s/^(.{0,80}).*?$/$1/g;
+		</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol Index - TOC - Pragma Mark.tmPreferences
+++ b/Symbol Index - TOC - Pragma Mark.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.pragma-mark - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^(.*?)\s*\\?\s*$\n?/$1/mg;
+		s/^.*$/### $0 ########################################################/g;
+		s/#  #/# ###/g;
+		s/^(.{0,80}).*?$/$1/g;
+		</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol Index - Task Tags - High priority.tmPreferences
+++ b/Symbol Index - Task Tags - High priority.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.task-tag.prio-high - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^(.*?)[\s\\]*$/ ǃǃ✔  $1/g;
+		</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol Index - Task Tags - Low priority.tmPreferences
+++ b/Symbol Index - Task Tags - Low priority.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.task-tag.prio-low - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^(.*?)[\s\\]*$/  ✅  $1/g;
+		</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol Index - Task Tags - Normal priority.tmPreferences
+++ b/Symbol Index - Task Tags - Normal priority.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.task-tag.prio-normal - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^(.*?)[\s\\]*$/  ✔  $1/g;
+		</string>
+    </dict>
+</dict>
+</plist>

--- a/Symbol Index - Task Tags.tmPreferences
+++ b/Symbol Index - Task Tags.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.c meta.toc-list.task-tag - punctuation.whitespace.newline</string>
+    <key>settings</key>
+    <dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>
+		s/^(.*?)[\s\\]*$/  ✎  $1/g;
+		</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This changes the way symbols and meta items are shown in the Ctrl+R list:

Code sections:
```
### Pragma mark section #############################
=== Banner comment section ==========================
```

Indexed symbols:

     ⒡  function_name ( ) ; — function declaration
    —Ⓕ– function_name ( ) { … } — function
     Ⓜ  macro_name … — macro object
    —Ⓜ– macro_name ( ) … — macro function
     ⒞  type_name ; — type declaration
    —Ⓒ– type_name { … } ; — type
     Ⓣ  name_t ; — typedef

Task tags:

      ✎  NOTE no need to optimize this logic
      ✅  REVIEW needed
      ✔  TODO pretty print the output
     ǃǃ✔  FIXME remove this shit ASAP

Contains #28 and #29, do not merge!