### PR TITLE
index: Don't filter out 'punctuation.whitespace.newline' scope

### DIFF
--- a/Symbol Index - TOC - Banner.tmPreferences
+++ b/Symbol Index - TOC - Banner.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.banner - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.banner</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index - TOC - Pragma Mark.tmPreferences
+++ b/Symbol Index - TOC - Pragma Mark.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.pragma-mark - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.pragma-mark</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index - Task Tags - High priority.tmPreferences
+++ b/Symbol Index - Task Tags - High priority.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.task-tag.prio-high - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.task-tag.prio-high</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index - Task Tags - Low priority.tmPreferences
+++ b/Symbol Index - Task Tags - Low priority.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.task-tag.prio-low - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.task-tag.prio-low</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index - Task Tags - Normal priority.tmPreferences
+++ b/Symbol Index - Task Tags - Normal priority.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.task-tag.prio-normal - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.task-tag.prio-normal</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>

--- a/Symbol Index - Task Tags.tmPreferences
+++ b/Symbol Index - Task Tags.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.c meta.toc-list.task-tag - punctuation.whitespace.newline</string>
+    <string>source.c meta.toc-list.task-tag</string>
     <key>settings</key>
     <dict>
 		<key>showInIndexedSymbolList</key>


### PR DESCRIPTION
This didn't work as intended anyway, instead it would break empty `#pragma mark` banners appearance in the Ctrl+R list.